### PR TITLE
Fixes to informer-cache PR

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,8 +1,26 @@
 package api
 
+import "strings"
+
 const (
 	UUIDLabel         = "buildkite.com/job-uuid"
 	TagLabel          = "buildkite.com/job-tag"
 	DefaultNamespace  = "default"
 	DefaultAgentImage = "ghcr.io/buildkite/agent-k8s:latest"
 )
+
+// a valid label must be an empty string or consist of alphanumeric characters,
+// '-', '_' or '.', and must start and end with an alphanumeric character (e.g.
+// 'MyValue',  or 'my_value',  or '12345', regex used for validation is
+// '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
+func TagToLabel(tag string) string {
+	return strings.ReplaceAll(tag, "=", "_")
+}
+
+func TagsToLabels(tags []string) []string {
+	labels := make([]string, len(tags))
+	for i, tag := range tags {
+		labels[i] = TagToLabel(tag)
+	}
+	return labels
+}

--- a/api/kubernetes.go
+++ b/api/kubernetes.go
@@ -17,12 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 )
 
-type BuildkiteJobManager struct {
-	batchv1.JobLister
-	kubernetes.Interface
-	Tags []string
-}
-
 // a valid label must be an empty string or consist of alphanumeric characters,
 // '-', '_' or '.', and must start and end with an alphanumeric character (e.g.
 // 'MyValue',  or 'my_value',  or '12345', regex used for validation is
@@ -39,7 +33,7 @@ func tagsToLabels(tags []string) []string {
 	return labels
 }
 
-func NewBuildkiteJobManagerOrDie(ctx context.Context, clientset kubernetes.Interface, tags ...string) *BuildkiteJobManager {
+func NewJobListerOrDie(ctx context.Context, clientset kubernetes.Interface, tags ...string) batchv1.JobLister {
 	hasTag, err := labels.NewRequirement(TagLabel, selection.In, tagsToLabels(tags))
 	if err != nil {
 		log.Panic("Failed to build tag label selector for job manager", err)
@@ -62,11 +56,7 @@ func NewBuildkiteJobManagerOrDie(ctx context.Context, clientset kubernetes.Inter
 		log.Panic(fmt.Errorf("Failed to sync informer cache"))
 	}
 
-	return &BuildkiteJobManager{
-		JobLister: informer.Lister(),
-		Interface: clientset,
-		Tags:      tags,
-	}
+	return informer.Lister()
 }
 
 func MetaJobLabelKeyFunc(obj interface{}) (string, error) {

--- a/api/kubernetes_test.go
+++ b/api/kubernetes_test.go
@@ -40,9 +40,9 @@ func TestBuildkiteJobManager(t *testing.T) {
 		},
 	}
 	client := fake.NewSimpleClientset(jobs...)
-	jobManager := NewBuildkiteJobManagerOrDie(context.Background(), client, tag)
+	lister := NewJobListerOrDie(context.Background(), client, tag)
 
-	jobList, err := jobManager.JobLister.List(labels.Everything())
+	jobList, err := lister.List(labels.Everything())
 	require.NoError(t, err)
 	require.Equal(t, 1, len(jobList))
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -110,14 +110,12 @@ func basicTest(t *testing.T, fixture, repo string) {
 
 	k8sClient, err := kubernetes.NewForConfig(clientConfig)
 	require.NoError(t, err)
-	tags := []string{fmt.Sprintf("queue=%s", pipelineName)}
-	jobLister := monitor.NewJobListerOrDie(ctx, k8sClient, tags...)
-	monitor := monitor.New(ctx, logger.Named("monitor"), jobLister, monitor.Config{
+	monitor, err := monitor.New(ctx, logger.Named("monitor"), k8sClient, monitor.Config{
 		Token:       token,
 		MaxInFlight: 1,
 		Org:         org,
 		Namespace:   api.DefaultNamespace,
-		Tags:        tags,
+		Tags:        []string{fmt.Sprintf("queue=%s", pipelineName)},
 	})
 	require.NoError(t, err)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -111,7 +111,7 @@ func basicTest(t *testing.T, fixture, repo string) {
 	k8sClient, err := kubernetes.NewForConfig(clientConfig)
 	require.NoError(t, err)
 	tags := []string{fmt.Sprintf("queue=%s", pipelineName)}
-	jobLister := api.NewJobListerOrDie(ctx, k8sClient, tags...)
+	jobLister := monitor.NewJobListerOrDie(ctx, k8sClient, tags...)
 	monitor := monitor.New(ctx, logger.Named("monitor"), jobLister, monitor.Config{
 		Token:       token,
 		MaxInFlight: 1,

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to create clienset", zap.Error(err))
 	}
-	jobLister := api.NewJobListerOrDie(ctx, k8sClient, *tags...)
+	jobLister := monitor.NewJobListerOrDie(ctx, k8sClient, *tags...)
 
 	monitor := monitor.New(ctx, log.Named("monitor"), jobLister, monitor.Config{
 		Namespace:   *ns,

--- a/main.go
+++ b/main.go
@@ -43,9 +43,7 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to create clienset", zap.Error(err))
 	}
-	jobLister := monitor.NewJobListerOrDie(ctx, k8sClient, *tags...)
-
-	monitor := monitor.New(ctx, log.Named("monitor"), jobLister, monitor.Config{
+	monitor, err := monitor.New(ctx, log.Named("monitor"), k8sClient, monitor.Config{
 		Namespace:   *ns,
 		Org:         org,
 		Token:       token,

--- a/main.go
+++ b/main.go
@@ -43,18 +43,19 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to create clienset", zap.Error(err))
 	}
-	jobManager := api.NewBuildkiteJobManagerOrDie(ctx, k8sClient, *tags...)
+	jobLister := api.NewJobListerOrDie(ctx, k8sClient, *tags...)
 
-	monitor := monitor.New(ctx, log.Named("monitor"), jobManager, monitor.Config{
+	monitor := monitor.New(ctx, log.Named("monitor"), jobLister, monitor.Config{
 		Namespace:   *ns,
 		Org:         org,
 		Token:       token,
 		MaxInFlight: *maxInFlight,
+		Tags:        *tags,
 	})
 	if err != nil {
 		zap.L().Fatal("failed to create monitor", zap.Error(err))
 	}
-	if err := scheduler.Run(ctx, zap.L().Named("scheduler"), monitor, jobManager, scheduler.Config{
+	if err := scheduler.Run(ctx, zap.L().Named("scheduler"), monitor, k8sClient, scheduler.Config{
 		Namespace:        *ns,
 		AgentTokenSecret: *agentTokenSecret,
 		JobTTL:           *jobTTL,

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 var debug *bool = flag.Bool("debug", false, "debug logs")
-var maxInFlight *int32 = flag.Int32("max-in-flight", 1, "max jobs in flight, 0 means no max")
+var maxInFlight *int = flag.Int("max-in-flight", 1, "max jobs in flight, 0 means no max")
 var jobTTL *time.Duration = flag.Duration("job-ttl", 10*time.Minute, "time to retain kubernetes jobs after completion")
 var agentTokenSecret *string = flag.String("agent-token-secret", "buildkite-agent-token", "name of the Buildkite agent token secret")
 var ns *string = flag.String("namespace", api.DefaultNamespace, "kubernetes namespace to create resources in")

--- a/monitor/lister_test.go
+++ b/monitor/lister_test.go
@@ -1,9 +1,10 @@
-package api
+package monitor
 
 import (
 	"context"
 	"testing"
 
+	"github.com/buildkite/agent-stack-k8s/api"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,7 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestBuildkiteJobManager(t *testing.T) {
+func TestJobLister(t *testing.T) {
 	tag := "some-tag=yep"
 	jobs := []runtime.Object{
 		&batchv1.Job{
@@ -24,8 +25,8 @@ func TestBuildkiteJobManager(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "different-tag",
 				Labels: map[string]string{
-					TagLabel:  "something-else",
-					UUIDLabel: "1",
+					api.TagLabel:  "something-else",
+					api.UUIDLabel: "1",
 				},
 			},
 		},
@@ -33,8 +34,8 @@ func TestBuildkiteJobManager(t *testing.T) {
 			ObjectMeta: v1.ObjectMeta{
 				Name: "matching-tag",
 				Labels: map[string]string{
-					TagLabel:  TagToLabel(tag),
-					UUIDLabel: "2",
+					api.TagLabel:  api.TagToLabel(tag),
+					api.UUIDLabel: "2",
 				},
 			},
 		},

--- a/monitor/lister_test.go
+++ b/monitor/lister_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buildkite/agent-stack-k8s/api"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -41,7 +42,8 @@ func TestJobLister(t *testing.T) {
 		},
 	}
 	client := fake.NewSimpleClientset(jobs...)
-	lister := NewJobListerOrDie(context.Background(), client, tag)
+	lister, err := NewJobLister(context.Background(), zap.Must(zap.NewDevelopment()), client, []string{tag})
+	require.NoError(t, err)
 
 	jobList, err := lister.List(labels.Everything())
 	require.NoError(t, err)

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -30,7 +30,7 @@ type Monitor struct {
 type Config struct {
 	Namespace   string
 	Token       string
-	MaxInFlight int32
+	MaxInFlight int
 	Org         string
 }
 
@@ -59,7 +59,7 @@ func (m *Monitor) Scheduled() <-chan Job {
 }
 
 func (m *Monitor) start() {
-	m.logger.Info("started", zap.String("org", m.cfg.Org), zap.String("namespace", m.cfg.Namespace), zap.Int32("max-in-flight", m.cfg.MaxInFlight))
+	m.logger.Info("started", zap.String("org", m.cfg.Org), zap.String("namespace", m.cfg.Namespace), zap.Int("max-in-flight", m.cfg.MaxInFlight))
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {
@@ -68,7 +68,7 @@ func (m *Monitor) start() {
 			return
 		case <-ticker.C:
 			if m.reachedMaxInFlight() {
-				m.logger.Info("max in flight reached", zap.Int32("in-flight", m.cfg.MaxInFlight))
+				m.logger.Info("max in flight reached", zap.Int("in-flight", m.cfg.MaxInFlight))
 				continue
 			}
 		Out:
@@ -109,7 +109,7 @@ func (m *Monitor) scheduleBuild(cmdJob *api.JobJobTypeCommand, tag string) error
 	if m.isJobInFlight(cmdJob.Uuid) {
 		m.logger.Debug("skipping already queued job", zap.String("uuid", cmdJob.Uuid))
 	} else if m.reachedMaxInFlight() {
-		m.logger.Debug("max in flight reached", zap.Int32("in-flight", m.cfg.MaxInFlight))
+		m.logger.Debug("max in flight reached", zap.Int("in-flight", m.cfg.MaxInFlight))
 		return &reachedMaxInFlight{}
 	} else {
 		m.jobs <- Job{
@@ -152,7 +152,7 @@ func (m *Monitor) reachedMaxInFlight() bool {
 	if m.cfg.MaxInFlight == 0 {
 		return false
 	}
-	var activeJobs int32
+	var activeJobs int
 	jobList, err := m.k8s.JobLister.List(labels.Everything())
 	if err != nil {
 		m.logger.Error(fmt.Sprintf("Unable to list active jobs: %s", err))

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -17,12 +17,13 @@ import (
 
 func TestInvalidOrg(t *testing.T) {
 	tags := []string{"foo=bar"}
-	m := New(context.Background(), zap.Must(zap.NewDevelopment()), NewJobListerOrDie(context.Background(), fake.NewSimpleClientset(), tags...), Config{
+	m, err := New(context.Background(), zap.Must(zap.NewDevelopment()), fake.NewSimpleClientset(), Config{
 		Token:       os.Getenv("BUILDKITE_TOKEN"),
 		MaxInFlight: 1,
 		Org:         "foo",
 		Tags:        tags,
 	})
+	require.NoError(t, err)
 	job := <-m.Scheduled()
 	require.ErrorContains(t, job.Err, "invalid organization")
 }
@@ -56,11 +57,13 @@ func TestScheduleBuild(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset(jobs...)
 
-	m := New(context.Background(), zap.Must(zap.NewDevelopment()), NewJobListerOrDie(context.Background(), client, tag), Config{
+	m, err := New(context.Background(), zap.Must(zap.NewDevelopment()), client, Config{
 		Token:       "test_token",
 		MaxInFlight: 1,
 		Org:         "foo",
+		Tags:        []string{tag},
 	})
+	require.NoError(t, err)
 	tests := []struct {
 		name           string
 		job            *api.JobJobTypeCommand

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -16,10 +16,12 @@ import (
 )
 
 func TestInvalidOrg(t *testing.T) {
-	m := New(context.Background(), zap.Must(zap.NewDevelopment()), api.NewBuildkiteJobManagerOrDie(context.Background(), fake.NewSimpleClientset(), "foo"), Config{
+	tags := []string{"foo=bar"}
+	m := New(context.Background(), zap.Must(zap.NewDevelopment()), api.NewJobListerOrDie(context.Background(), fake.NewSimpleClientset(), tags...), Config{
 		Token:       os.Getenv("BUILDKITE_TOKEN"),
 		MaxInFlight: 1,
 		Org:         "foo",
+		Tags:        tags,
 	})
 	job := <-m.Scheduled()
 	require.ErrorContains(t, job.Err, "invalid organization")
@@ -54,7 +56,7 @@ func TestScheduleBuild(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset(jobs...)
 
-	m := New(context.Background(), zap.Must(zap.NewDevelopment()), api.NewBuildkiteJobManagerOrDie(context.Background(), client, tag), Config{
+	m := New(context.Background(), zap.Must(zap.NewDevelopment()), api.NewJobListerOrDie(context.Background(), client, tag), Config{
 		Token:       "test_token",
 		MaxInFlight: 1,
 		Org:         "foo",

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestInvalidOrg(t *testing.T) {
 	tags := []string{"foo=bar"}
-	m := New(context.Background(), zap.Must(zap.NewDevelopment()), api.NewJobListerOrDie(context.Background(), fake.NewSimpleClientset(), tags...), Config{
+	m := New(context.Background(), zap.Must(zap.NewDevelopment()), NewJobListerOrDie(context.Background(), fake.NewSimpleClientset(), tags...), Config{
 		Token:       os.Getenv("BUILDKITE_TOKEN"),
 		MaxInFlight: 1,
 		Org:         "foo",
@@ -56,7 +56,7 @@ func TestScheduleBuild(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset(jobs...)
 
-	m := New(context.Background(), zap.Must(zap.NewDevelopment()), api.NewJobListerOrDie(context.Background(), client, tag), Config{
+	m := New(context.Background(), zap.Must(zap.NewDevelopment()), NewJobListerOrDie(context.Background(), client, tag), Config{
 		Token:       "test_token",
 		MaxInFlight: 1,
 		Org:         "foo",

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestInvalidOrg(t *testing.T) {
-	m := New(context.Background(), zap.Must(zap.NewDevelopment()), api.NewBuildkiteJobManagerOrDie(context.Background(), fake.NewSimpleClientset()), Config{
+	m := New(context.Background(), zap.Must(zap.NewDevelopment()), api.NewBuildkiteJobManagerOrDie(context.Background(), fake.NewSimpleClientset(), "foo"), Config{
 		Token:       os.Getenv("BUILDKITE_TOKEN"),
 		MaxInFlight: 1,
 		Org:         "foo",

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -15,6 +15,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 )
 
@@ -39,7 +40,7 @@ func (c Config) WithDefaults() Config {
 	return c
 }
 
-func Run(ctx context.Context, logger *zap.Logger, monitor *monitor.Monitor, client *api.BuildkiteJobManager, cfg Config) error {
+func Run(ctx context.Context, logger *zap.Logger, monitor *monitor.Monitor, client kubernetes.Interface, cfg Config) error {
 	worker := worker{
 		ctx:    ctx,
 		cfg:    cfg,
@@ -272,7 +273,7 @@ func (w *worker) k8sify(
 type worker struct {
 	ctx    context.Context
 	cfg    Config
-	client *api.BuildkiteJobManager
+	client kubernetes.Interface
 	logger *zap.Logger
 }
 


### PR DESCRIPTION
Had a look and took some initiative on some opinions, hope you don't mind 😄 

I moved the JobManager into the monitor package, and made it just a lister. I think this results in it being a smaller change, we don't need to pass the manager to anyone other than the monitor, and it's kind of confusing to have it be this hybrid object that has both a Lister and a kubernetes.Interface on it. The scheduler doesn't need the Lister at all, so this ends up keeping that file/package the same.